### PR TITLE
Fix defaults for username

### DIFF
--- a/pyOlog/conf.py
+++ b/pyOlog/conf.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 class Config(object):
     defaults = {'url': 'http://localhost:8181/Olog',
-                'username': os.environ['USER']}
+                'username': getpass.getuser()}
     conf_files = ['/etc/pyOlog.conf',
                   os.path.expanduser('~/pyOlog.conf'),
                   os.path.expanduser('~/.pyOlog.conf'),


### PR DESCRIPTION
The user name environment variable in Windows is `USERNAME` (see https://pureinfotech.com/list-environment-variables-windows-10/ for details), so that the default configuration with `os.environ['USER']` is only applicable to Linux/OSX. This PR resolves it by using a more universal [`getpass.getuser()`](https://github.com/python/cpython/blob/9da28d2b3429d1bb30e082e4c9cb544d81fdae20/Lib/getpass.py#L154-L165), as:

> This works on Windows as long as USERNAME is set.

See https://github.com/conda-forge/staged-recipes/pull/15526 for the context.