### PR TITLE
Use `configparser.ConfigParser`

### DIFF
--- a/pyOlog/conf.py
+++ b/pyOlog/conf.py
@@ -34,7 +34,7 @@ class Config(object):
         self.heading = conf
 
         from six.moves import configparser
-        self.cf = configparser.SafeConfigParser(defaults=self.defaults)
+        self.cf = configparser.ConfigParser(defaults=self.defaults)
         files = self.cf.read(self.conf_files)
 
         for f in files:

--- a/test/_testConf.py
+++ b/test/_testConf.py
@@ -10,9 +10,9 @@ url=http://localhost:8000/Olog
 
 def __loadConfig():
     import os.path
-    import ConfigParser
+    import configparser
     dflt={'url':'https://localhost:8181/Olog'}
-    cf=ConfigParser.SafeConfigParser(defaults=dflt)
+    cf=configparser.ConfigParser(defaults=dflt)
     cf.read([
         '/etc/pyOlog.conf',
         os.path.expanduser('~/pyOlog.conf'),


### PR DESCRIPTION
Our conda environments using python 3.12 are unable to launch bsui with pyOlog because of references to `SafeConfigParser`.

This PR upgrades to instead use `configparser.ConfigParser`.
https://docs.python.org/3.12/whatsnew/3.12.html#configparser